### PR TITLE
Localized localization_data first pass

### DIFF
--- a/localization_data.json
+++ b/localization_data.json
@@ -79,9 +79,8 @@
 		]
 	},
 
-
 	"he": {
-		"language": "עִבְרִית",
+		"language": "עברית",
 		"currency_symbol": "$",
 		"nux_landing_page_string": "שלב",
 		"wpcom_landing_page_string": "התחבר",


### PR DESCRIPTION
Setting the accept language in the browser means that the Adwords
UI is localized, so we need the language and place names in the local languages.